### PR TITLE
Relax client version parsing constraint

### DIFF
--- a/msg_client_test.go
+++ b/msg_client_test.go
@@ -95,7 +95,10 @@ func TestClientMsgParse(t *testing.T) {
 			{"MissingIdkField", sqrl.Base64.EncodeToString([]byte("ver=1\ncmd=query"))},
 			{"MissingCmdField", sqrl.Base64.EncodeToString([]byte("ver=1\nidk=" + validIdk))},
 			{"MissingVerField", sqrl.Base64.EncodeToString([]byte("cmd=query\nidk=" + validIdk))},
-			{"VerNotFirst", sqrl.Base64.EncodeToString([]byte("cmd=query\nver=1\nidk=" + validIdk))},
+			// The Web extension does not lead with the version information
+			// TODO: Is this a bug in the extension? Or should we relax this constraint?
+			// https://github.com/RaniSputnik/sqrl-go/issues/12
+			// {"VerNotFirst", sqrl.Base64.EncodeToString([]byte("cmd=query\nver=1\nidk=" + validIdk))},
 		}
 
 		for _, testCase := range cases {

--- a/msg_common.go
+++ b/msg_common.go
@@ -18,11 +18,6 @@ func parseMsg(raw string) (map[string]string, error) {
 		return nil, err
 	}
 
-	// TODO: avoid parsing ver parameter twice
-	if !strings.HasPrefix(string(bytes), "ver=") {
-		return nil, errors.New("must start with ver parameter")
-	}
-
 	form := strings.Split(string(bytes), "\n")
 
 	vals := map[string]string{}


### PR DESCRIPTION
Not sure if this is a bug in the web extension or if we should be relaxing this constraint, unclear from
current SQRL spec. For now, will remove the requirement that the ver key comes first in the client message.

Addresses #12