### PR TITLE
CPS URL

### DIFF
--- a/msg_client.go
+++ b/msg_client.go
@@ -29,10 +29,24 @@ func (m *ClientMsg) Encode() (string, error) {
 		"ver=" + strings.Join(m.Ver, ","),
 		"cmd=" + string(m.Cmd),
 		"idk=" + string(m.Idk),
-
-		"", // Must end with a final newline
 	}
+	if len(m.Opt) > 0 {
+		vals = append(vals, "opt="+encodeOptions(m.Opt))
+	}
+	vals = append(vals, "") // Must end with a final newline
 	return Base64.EncodeToString([]byte(strings.Join(vals, "\r\n"))), nil
+}
+
+func encodeOptions(opts []Opt) string {
+	res := ""
+	lastOpt := len(opts) - 1
+	for i, opt := range opts {
+		res += string(opt)
+		if i != lastOpt {
+			res += "~"
+		}
+	}
+	return res
 }
 
 // HasOpt returns true/false whether the given option was provided.
@@ -68,7 +82,24 @@ func ParseClient(raw string) (*ClientMsg, error) {
 		Ver: ver,
 		Cmd: Cmd(vals["cmd"]),
 		Idk: Identity(vals["idk"]),
-
-		Opt: nil, // TODO: support parsing opt values
+		Opt: parseOpts(vals["opt"]),
 	}, nil
+}
+
+func parseOpts(input string) []Opt {
+	if input == "" {
+		return []Opt{}
+	}
+
+	// TODO: Remove strings.Split and reduce allocations
+	inputs := strings.Split(input, "~")
+	opts := make([]Opt, len(inputs))
+	for i, optString := range inputs {
+		opts[i] = Opt(optString)
+	}
+
+	// TODO: Do we want to check for validity of options?
+	// Or do we simply ignore options we don't understand?
+
+	return opts
 }

--- a/msg_client_test.go
+++ b/msg_client_test.go
@@ -1,6 +1,7 @@
 package sqrl_test
 
 import (
+	"fmt"
 	"testing"
 
 	sqrl "github.com/RaniSputnik/sqrl-go"
@@ -65,6 +66,26 @@ func TestClientMsgEncode(t *testing.T) {
 				},
 				Expect: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCg",
 			},
+			{
+				Name: "Query with single option",
+				Input: sqrl.ClientMsg{
+					Ver: []string{sqrl.V1},
+					Cmd: sqrl.CmdQuery,
+					Idk: validIdk,
+					Opt: []sqrl.Opt{sqrl.OptCPS},
+				},
+				Expect: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCm9wdD1jcHMNCg",
+			},
+			{
+				Name: "Query with two options",
+				Input: sqrl.ClientMsg{
+					Ver: []string{sqrl.V1},
+					Cmd: sqrl.CmdQuery,
+					Idk: validIdk,
+					Opt: []sqrl.Opt{sqrl.OptCPS, sqrl.OptSQRLOnly},
+				},
+				Expect: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCm9wdD1jcHN-c3FybG9ubHkNCg",
+			},
 		}
 
 		for _, test := range cases {
@@ -111,32 +132,58 @@ func TestClientMsgParse(t *testing.T) {
 
 	t.Run("ReturnsValidClient", func(t *testing.T) {
 		cases := []struct {
+			Name     string
 			Input    string
 			Expected sqrl.ClientMsg
 		}{
 			{
+				Name:  "Basic query",
 				Input: "dmVyPTEKY21kPXF1ZXJ5Cmlkaz1WbDRLVlZSb0cwQzh2MVZQMFVFVU5LMnpfU1loTlZZQlhkb2FyaE1sanpRCg",
 				Expected: sqrl.ClientMsg{
 					Ver: []string{sqrl.V1},
 					Cmd: sqrl.CmdQuery,
 					Idk: validIdk,
+					Opt: []sqrl.Opt{},
 				},
 			},
 			{
+				Name:  "Basic query, alternative newline characters",
 				Input: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCg",
 				Expected: sqrl.ClientMsg{
 					Ver: []string{sqrl.V1},
 					Cmd: sqrl.CmdQuery,
 					Idk: validIdk,
+					Opt: []sqrl.Opt{},
+				},
+			},
+			{
+				Name:  "Query with single option",
+				Input: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCm9wdD1jcHMNCg",
+				Expected: sqrl.ClientMsg{
+					Ver: []string{sqrl.V1},
+					Cmd: sqrl.CmdQuery,
+					Idk: validIdk,
+					Opt: []sqrl.Opt{sqrl.OptCPS},
+				},
+			},
+			{
+				Name:  "Query with two options",
+				Input: "dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVZsNEtWVlJvRzBDOHYxVlAwVUVVTksyel9TWWhOVllCWGRvYXJoTWxqelENCm9wdD1jcHN-c3FybG9ubHkNCg",
+				Expected: sqrl.ClientMsg{
+					Ver: []string{sqrl.V1},
+					Cmd: sqrl.CmdQuery,
+					Idk: validIdk,
+					Opt: []sqrl.Opt{sqrl.OptCPS, sqrl.OptSQRLOnly},
 				},
 			},
 		}
 
 		for _, test := range cases {
 			got, err := sqrl.ParseClient(test.Input)
-			assert.NoError(t, err)
-			if assert.NotNil(t, got) {
-				assert.Equal(t, test.Expected, *got)
+			assert.NoError(t, err, fmt.Sprintf("'%s' failed, returned an error", test.Name))
+			if assert.NotNil(t, got, fmt.Sprintf("'%s' failed, result was nil", test.Name)) {
+				assert.Equal(t, test.Expected, *got,
+					fmt.Sprintf("'%s' failed, result did not match expected value", test.Name))
 			}
 		}
 	})

--- a/msg_server.go
+++ b/msg_server.go
@@ -17,8 +17,8 @@ type ServerMsg struct {
 	Nut Nut
 	Tif TIF
 	Qry string
+	URL string
 
-	// TODO: url - for any command other than query
 	// TODO: sin - Secret index
 	// TODO: suk - server unlock key
 	// TODO: ask - message text to display to user
@@ -35,8 +35,11 @@ func (m *ServerMsg) Encode() (string, error) {
 		"nut=" + string(m.Nut),
 		"tif=" + strconv.Itoa(int(m.Tif)),
 		"qry=" + m.Qry,
-		"", // Must end with a final newline
 	}
+	if m.URL != "" {
+		vals = append(vals, "url="+m.URL)
+	}
+	vals = append(vals, "") // Must end with a final newline
 	return Base64.EncodeToString([]byte(strings.Join(vals, "\r\n"))), nil
 }
 
@@ -90,5 +93,6 @@ func ParseServer(raw string) (*ServerMsg, error) {
 		Nut: nut,
 		Tif: TIF(tif),
 		Qry: vals["qry"],
+		URL: vals["url"],
 	}, nil
 }

--- a/msg_server_test.go
+++ b/msg_server_test.go
@@ -3,7 +3,7 @@ package sqrl_test
 import (
 	"testing"
 
-	"github.com/RaniSputnik/sqrl-go"
+	sqrl "github.com/RaniSputnik/sqrl-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +21,16 @@ func TestServerMsgEncode(t *testing.T) {
 					Qry: "/sqrl?nut=bRW-IegCUhGmcz9yvTtDKA",
 				},
 				Expect: "dmVyPTENCm51dD1iUlctSWVnQ1VoR21jejl5dlR0REtBDQp0aWY9NQ0KcXJ5PS9zcXJsP251dD1iUlctSWVnQ1VoR21jejl5dlR0REtBDQo",
+			},
+			{
+				Input: sqrl.ServerMsg{
+					Ver: []string{sqrl.V1},
+					Nut: "foo",
+					Tif: sqrl.TIF(5),
+					Qry: "/sqrl?nut=foo",
+					URL: "https://sqrl.example.com?123456789",
+				},
+				Expect: "dmVyPTENCm51dD1mb28NCnRpZj01DQpxcnk9L3Nxcmw_bnV0PWZvbw0KdXJsPWh0dHBzOi8vc3FybC5leGFtcGxlLmNvbT8xMjM0NTY3ODkNCg",
 			},
 		}
 
@@ -55,6 +65,16 @@ func TestServerMsgParse(t *testing.T) {
 					Tif: 4,
 					Qry: "/sqrl?nut=QLYNwSvLFLegwE9U1FrHnA",
 					// TODO: Sin: 0,
+				},
+			},
+			{
+				Input: "dmVyPTENCm51dD1mb28NCnRpZj01DQpxcnk9L3Nxcmw_bnV0PWZvbw0KdXJsPWh0dHBzOi8vc3FybC5leGFtcGxlLmNvbT8xMjM0NTY3ODkNCg",
+				Expect: sqrl.ServerMsg{
+					Ver: []string{sqrl.V1},
+					Nut: "foo",
+					Tif: 5,
+					Qry: "/sqrl?nut=foo",
+					URL: "https://sqrl.example.com?123456789",
 				},
 			},
 		}

--- a/ssp/authenticate.go
+++ b/ssp/authenticate.go
@@ -85,6 +85,12 @@ func Authenticate(server *sqrl.Server, delegate Delegate) http.Handler {
 				serverError(response)
 			}
 
+			if client.HasOpt(sqrl.OptCPS) {
+				// TODO: Configure the redirect URL for authentication
+				token := "todo-token"
+				response.URL = "http://localhost:8080?" + token
+			}
+
 		case sqrl.CmdQuery:
 			// Do nothing
 
@@ -96,11 +102,14 @@ func Authenticate(server *sqrl.Server, delegate Delegate) http.Handler {
 }
 
 func genNextResponse(server *sqrl.Server, r *http.Request) *sqrl.ServerMsg {
+	// TODO: How to configure this endpoint?
+	endpoint := "/sqrl" + r.URL.Path
+
 	nextNut := server.Nut(clientID(r))
 	return &sqrl.ServerMsg{
 		Ver: v1Only,
 		Nut: nextNut,
-		Qry: r.URL.Path + "?nut=" + string(nextNut),
+		Qry: endpoint + "?nut=" + string(nextNut),
 	}
 }
 

--- a/ssp/delegate_inmemory.go
+++ b/ssp/delegate_inmemory.go
@@ -1,0 +1,21 @@
+package ssp
+
+import (
+	"context"
+
+	sqrl "github.com/RaniSputnik/sqrl-go"
+)
+
+type inmemoryDelegate struct{}
+
+func TODODelegate() Delegate {
+	return &inmemoryDelegate{}
+}
+
+func (d *inmemoryDelegate) Known(ctx context.Context, id sqrl.Identity) (bool, error) {
+	return false, nil
+}
+
+func (d *inmemoryDelegate) Authenticated(ctx context.Context, id sqrl.Identity) error {
+	return nil
+}

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -22,6 +22,7 @@ func Handler(key []byte) http.Handler {
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", nutHandler(s, logger))
 	r.HandleFunc("/qr.png", qrHandler(s, logger))
+	r.Handle("/cli.sqrl", Authenticate(s, TODODelegate()))
 	return r
 }
 


### PR DESCRIPTION
When the client provides the CPS option we should return the URL in the response to the client and ignore polling from the browser as described in https://github.com/RaniSputnik/sqrl-go/issues/13. The goal of this work will be to successfully authenticate with the SQRL browser extension.

### TODO

- [x] Add opt encoding / parsing to client msg
- [x] Add URL field to server msg
- [x] Add `cli.sqrl` "authenticate" endpoint
- [x] Return URL when CPS option provided by client
- [ ] Write tests for Authenticate HTTP handler CPS behaviour

### Future work

- Make Redirect URL configurable (ie. Not hardcoded to localhost)
- Make qry field in server response configurable