### PR TITLE
Configure endpoints

### DIFF
--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package sqrl
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"strings"
 	"time"
 )
 
@@ -11,6 +12,8 @@ import (
 type Server struct {
 	aesgcm    cipher.AEAD
 	nutExpiry time.Duration
+
+	redirectURL string
 }
 
 // Configure creates a new SQRL server
@@ -19,7 +22,10 @@ type Server struct {
 // TODO: Key rotation
 func Configure(key []byte) *Server {
 	aesgcm := genAesgcm(key)
-	return &Server{aesgcm, time.Minute * 5}
+	return &Server{
+		aesgcm:    aesgcm,
+		nutExpiry: time.Minute * 5,
+	}
 }
 
 func genAesgcm(key []byte) cipher.AEAD {
@@ -42,7 +48,38 @@ func padKeyIfRequired(key []byte) {
 // WithNutExpiry sets the window of time within which
 // a nut is considered to be valid.
 func (s *Server) WithNutExpiry(d time.Duration) *Server {
-	// TODO: Mutex?
 	s.nutExpiry = d
 	return s
+}
+
+// WithRedirectURL sets the endpoint that the SQRL server
+// will redirect to when authentication is successful.
+//
+// When redirecting the SQRL server will add a ? then the
+// authentication token that can be used to retrieve the
+// session eg. If the URL https://example.com is provided
+// tokens will be returned to https://example.com?12345678
+func (s *Server) WithRedirectURL(url string) *Server {
+	i := strings.LastIndexByte(url, '?')
+	if i > -1 {
+		s.redirectURL = url[:i]
+	} else {
+		s.redirectURL = url
+	}
+	return s
+}
+
+// TODO: Do we need to expose these getters?
+// Complicates the interface a little, maybe would
+// be better as a simple struct?
+
+func (s *Server) NutExpiry() time.Duration {
+	return s.nutExpiry
+}
+
+func (s *Server) RedirectURL() string {
+	if s.redirectURL == "" {
+		return "/"
+	}
+	return s.redirectURL
 }

--- a/server.go
+++ b/server.go
@@ -13,7 +13,8 @@ type Server struct {
 	aesgcm    cipher.AEAD
 	nutExpiry time.Duration
 
-	redirectURL string
+	redirectURL    string
+	clientEndpoint string
 }
 
 // Configure creates a new SQRL server
@@ -23,8 +24,10 @@ type Server struct {
 func Configure(key []byte) *Server {
 	aesgcm := genAesgcm(key)
 	return &Server{
-		aesgcm:    aesgcm,
-		nutExpiry: time.Minute * 5,
+		aesgcm:         aesgcm,
+		nutExpiry:      time.Minute * 5,
+		redirectURL:    "/",
+		clientEndpoint: "/cli.sqrl",
 	}
 }
 
@@ -69,6 +72,16 @@ func (s *Server) WithRedirectURL(url string) *Server {
 	return s
 }
 
+// WithCLientURL sets the endpoint that the client can
+// use to post SQRL transactions to. This endpoint should
+// be the path relative to the SQRL domain eg. /sqrl/cli.sqrl
+//
+// Defaults to /cli.sqrl if not set.
+func (s *Server) WithCLientEndpoint(url string) *Server {
+	s.clientEndpoint = url
+	return s
+}
+
 // TODO: Do we need to expose these getters?
 // Complicates the interface a little, maybe would
 // be better as a simple struct?
@@ -78,8 +91,9 @@ func (s *Server) NutExpiry() time.Duration {
 }
 
 func (s *Server) RedirectURL() string {
-	if s.redirectURL == "" {
-		return "/"
-	}
 	return s.redirectURL
+}
+
+func (s *Server) ClientEndpoint() string {
+	return s.clientEndpoint
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,32 @@
+package sqrl_test
+
+import (
+	"testing"
+
+	sqrl "github.com/RaniSputnik/sqrl-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerRedirectURL(t *testing.T) {
+	anyKey := make([]byte, 16)
+
+	t.Run("DefaultsToIndexURL", func(t *testing.T) {
+		s := sqrl.Configure(anyKey)
+		assert.Equal(t, s.RedirectURL(), "/")
+	})
+
+	t.Run("RespectsTheSpecifiedRedirectURL", func(t *testing.T) {
+		s := sqrl.Configure(anyKey).WithRedirectURL("https://example.com")
+		assert.Equal(t, s.RedirectURL(), "https://example.com")
+	})
+
+	t.Run("HandlesURLsWithPaths", func(t *testing.T) {
+		s := sqrl.Configure(anyKey).WithRedirectURL("https://example.com/foo/bar")
+		assert.Equal(t, s.RedirectURL(), "https://example.com/foo/bar")
+	})
+
+	t.Run("StripsAnyQueryStringParams", func(t *testing.T) {
+		s := sqrl.Configure(anyKey).WithRedirectURL("https://example.com?foo=bar")
+		assert.Equal(t, s.RedirectURL(), "https://example.com")
+	})
+}

--- a/ssp/authenticate.go
+++ b/ssp/authenticate.go
@@ -1,6 +1,7 @@
 package ssp
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -88,7 +89,7 @@ func Authenticate(server *sqrl.Server, delegate Delegate) http.Handler {
 			if client.HasOpt(sqrl.OptCPS) {
 				// TODO: Configure the redirect URL for authentication
 				token := "todo-token"
-				response.URL = "http://localhost:8080?" + token
+				response.URL = fmt.Sprintf("%s?%s", server.RedirectURL(), token)
 			}
 
 		case sqrl.CmdQuery:

--- a/ssp/authenticate.go
+++ b/ssp/authenticate.go
@@ -103,14 +103,11 @@ func Authenticate(server *sqrl.Server, delegate Delegate) http.Handler {
 }
 
 func genNextResponse(server *sqrl.Server, r *http.Request) *sqrl.ServerMsg {
-	// TODO: How to configure this endpoint?
-	endpoint := "/sqrl" + r.URL.Path
-
 	nextNut := server.Nut(clientID(r))
 	return &sqrl.ServerMsg{
 		Ver: v1Only,
 		Nut: nextNut,
-		Qry: endpoint + "?nut=" + string(nextNut),
+		Qry: server.ClientEndpoint() + "?nut=" + string(nextNut),
 	}
 }
 

--- a/ssp/example/main.go
+++ b/ssp/example/main.go
@@ -20,7 +20,12 @@ func main() {
 	// http://www.gorillatoolkit.org/pkg/handlers#CORSOption
 	config := sqrl.Configure(todoKey).
 		WithNutExpiry(time.Minute * 5).
-		WithRedirectURL("http://localhost:8080")
+		WithRedirectURL("http://localhost:8080").
+		// TODO: bit lame that this cli.sqrl is both hardcoded
+		// in ssp and configured here. Should we only provide
+		// the /sqrl part here? Or should cli.sqrl be moved out
+		// of ssp.Handler?
+		WithCLientEndpoint("/sqrl/cli.sqrl")
 
 	dir := "static"
 	fs := http.FileServer(http.Dir(dir))

--- a/ssp/example/main.go
+++ b/ssp/example/main.go
@@ -4,7 +4,9 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"time"
 
+	sqrl "github.com/RaniSputnik/sqrl-go"
 	"github.com/RaniSputnik/sqrl-go/ssp"
 )
 
@@ -12,12 +14,20 @@ import (
 var todoKey = make([]byte, 16)
 
 func main() {
+	// TODO: This builder is a bit gross
+	// Maybe we can move to using option functions
+	// like Gorilla Handlers?
+	// http://www.gorillatoolkit.org/pkg/handlers#CORSOption
+	config := sqrl.Configure(todoKey).
+		WithNutExpiry(time.Minute * 5).
+		WithRedirectURL("http://localhost:8080")
+
 	dir := "static"
 	fs := http.FileServer(http.Dir(dir))
 	http.Handle("/static/", http.StripPrefix("/static", fs))
 	// TODO: Don't strip the trailing slash here or else gorilla Mux will become confused
 	// and attempt to clean+rediect. Is this something that we should handle in library code?
-	http.Handle("/sqrl/", http.StripPrefix("/sqrl", ssp.Handler(todoKey)))
+	http.Handle("/sqrl/", http.StripPrefix("/sqrl", ssp.Handler(config)))
 	http.Handle("/", indexHandler())
 
 	port := ":8080"

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -14,10 +14,9 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func Handler(key []byte) http.Handler {
+func Handler(s *sqrl.Server) http.Handler {
 	// TODO: Make this configurable
 	logger := log.New(os.Stdout, "", 0)
-	s := sqrl.Configure(key)
 
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", nutHandler(s, logger))

--- a/ssp/handler_test.go
+++ b/ssp/handler_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/RaniSputnik/sqrl-go/ssp"
 )
 
-var anyKey = make([]byte, 16)
-
 const validNut = "rNRqu8olcWLAPaDvsL4b6owTVfryjzbre3hWHWnNTrK_hIS_KgIDFt2eBDc"
 
 func TestHandlerNutIsReturned(t *testing.T) {
-	s := httptest.NewServer(ssp.Handler(anyKey))
+	s := httptest.NewServer(ssp.Handler(anyServer()))
 	res, err := http.Get(s.URL + "/nut.json")
 
 	// Assert no errors
@@ -46,7 +44,7 @@ func TestHandlerNutIsReturned(t *testing.T) {
 }
 
 func TestHandlerNutIsUnique(t *testing.T) {
-	s := httptest.NewServer(ssp.Handler(anyKey))
+	s := httptest.NewServer(ssp.Handler(anyServer()))
 	endpoint := s.URL + "/nut.json"
 
 	type nutRes struct {
@@ -72,7 +70,7 @@ func TestHandlerNutIsUnique(t *testing.T) {
 }
 
 func TestQRCodeIsReturned(t *testing.T) {
-	s := httptest.NewServer(ssp.Handler(anyKey))
+	s := httptest.NewServer(ssp.Handler(anyServer()))
 	res, err := http.Get(s.URL + "/qr.png?nut=" + validNut)
 
 	// Assert no errors
@@ -98,7 +96,7 @@ func TestQRCodeIsReturned(t *testing.T) {
 func TestQRCodeIsReturnedAtSpecifiedSize(t *testing.T) {
 	const givenSize = 64
 
-	s := httptest.NewServer(ssp.Handler(anyKey))
+	s := httptest.NewServer(ssp.Handler(anyServer()))
 	res, err := http.Get(fmt.Sprintf("%s/qr.png?nut=%s&size=%d", s.URL, validNut, givenSize))
 	fatal(t, assert.NoError(t, err,
 		"Expected no HTTP/connection error"))


### PR DESCRIPTION
Allow both the redirect URL and client endpoints to be configured.

Resolves #18 
Resolves #14  