### PR TITLE
Token Exchange

### DIFF
--- a/server.go
+++ b/server.go
@@ -85,12 +85,12 @@ func (s *Server) WithRedirectURL(url string) *Server {
 	return s
 }
 
-// WithCLientURL sets the endpoint that the client can
+// WithClientEndpoint sets the endpoint that the client can
 // use to post SQRL transactions to. This endpoint should
 // be the path relative to the SQRL domain eg. /sqrl/cli.sqrl
 //
 // Defaults to /cli.sqrl if not set.
-func (s *Server) WithCLientEndpoint(url string) *Server {
+func (s *Server) WithClientEndpoint(url string) *Server {
 	s.clientEndpoint = url
 	return s
 }

--- a/server.go
+++ b/server.go
@@ -10,11 +10,23 @@ import (
 // Server is a SQRL compliant server configured
 // with nut encryption keys and expiry times.
 type Server struct {
+	key       []byte
 	aesgcm    cipher.AEAD
 	nutExpiry time.Duration
 
 	redirectURL    string
 	clientEndpoint string
+}
+
+// Key returns the AES key used
+// by the server for nut generation
+//
+// This is currently used by the
+// SSP package to share a single key
+// between servers. Can we do better
+// than this?
+func (s *Server) Key() []byte {
+	return s.key
 }
 
 // Configure creates a new SQRL server
@@ -24,6 +36,7 @@ type Server struct {
 func Configure(key []byte) *Server {
 	aesgcm := genAesgcm(key)
 	return &Server{
+		key:            key,
 		aesgcm:         aesgcm,
 		nutExpiry:      time.Minute * 5,
 		redirectURL:    "/",

--- a/ssp/authenticate.go
+++ b/ssp/authenticate.go
@@ -24,7 +24,7 @@ func serverError(response *sqrl.ServerMsg) {
 // TODO: This method is ridiculously large, we should be able to break it down
 // and move some of the functionality (particularly validation) to the core SQRL
 // package for folks who don't need a SSP server.
-func Authenticate(server *sqrl.Server, store Store, tokens *TokenGenerator, userStore UserStore) http.Handler {
+func Authenticate(server *sqrl.Server, store Store, tokens *TokenGenerator) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		log.Printf("Got SQRL request: %v\n", r)
@@ -91,7 +91,7 @@ func Authenticate(server *sqrl.Server, store Store, tokens *TokenGenerator, user
 		// TODO: Test for IP Match
 
 		// TODO: Pass previous identities to "GetByIdentity"
-		currentUser, err := userStore.GetUserByIdentity(ctx, client.Idk)
+		currentUser, err := store.GetUserByIdentity(ctx, client.Idk)
 		if err != nil {
 			log.Printf("Failed to determine if identity is known: %v\n", err)
 			serverError(response)
@@ -104,7 +104,7 @@ func Authenticate(server *sqrl.Server, store Store, tokens *TokenGenerator, user
 		case sqrl.CmdIdent:
 			// Create user if they do not already exist
 			if currentUser == nil {
-				currentUser, err = userStore.CreateUser(ctx, client.Idk)
+				currentUser, err = store.CreateUser(ctx, client.Idk)
 				if err != nil {
 					log.Printf("Failed to create user: %v\n", err)
 					serverError(response)

--- a/ssp/authenticate.go
+++ b/ssp/authenticate.go
@@ -1,7 +1,6 @@
 package ssp
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -110,7 +109,7 @@ func Authenticate(server *sqrl.Server, store Store) http.Handler {
 			}
 
 			if client.HasOpt(sqrl.OptCPS) {
-				response.URL = fmt.Sprintf("%s?%s", server.RedirectURL(), token)
+				response.URL = getTokenRedirectURL(server, token)
 			}
 		case sqrl.CmdQuery:
 			// TODO: Anything need to be done here?

--- a/ssp/authenticate_test.go
+++ b/ssp/authenticate_test.go
@@ -25,7 +25,7 @@ const validQueryBody = "client=dmVyPTENCmNtZD1xdWVyeQ0KaWRrPVpIa2RQTDM0eWFhSmR5a
 const validIdentBody = "client=dmVyPTENCmNtZD1pZGVudA0KaWRrPVpIa2RQTDM0eWFhSmR5aUtVT1F1SS1zMmtqei1uSGcwVU5RMFpBcjZlZHMNCg&server=dmVyPTENCm51dD01aHFaS3VIeXE1dDZ5Mmlmb1czd1B3DQp0aWY9NQ0KcXJ5PS9zcXJsP251dD01aHFaS3VIeXE1dDZ5Mmlmb1czd1B3DQo&ids=z__MvVTGpeDLLPj3O9QLNrkcvsk_8iuipu-DWalCfQWuP1xXom3HW1MhXNOYYhYiO2Kx2qMgT3D0uze3hdYLDg"
 
 func TestAuthenticateReturnsClientErrorWhenContentTypeIsNotFormEncoded(t *testing.T) {
-	h := ssp.Authenticate(anyServer(), NewStore())
+	h := ssp.Authenticate(anyServer(), NewStore(), anyTokenGenerator())
 	w, r := setupAuthenticate(emptyBody)
 	r.Header.Set("Content-Type", "application/json")
 
@@ -43,7 +43,7 @@ func TestAuthenticateReturnsClientErrorWhenContentTypeIsNotFormEncoded(t *testin
 // TODO: Invalid Server Param
 
 func TestAuthenticateReturnsClientFailureWhenClientParamIsMissing(t *testing.T) {
-	h := ssp.Authenticate(anyServer(), NewStore())
+	h := ssp.Authenticate(anyServer(), NewStore(), anyTokenGenerator())
 	w, r := setupAuthenticate(fmt.Sprintf("server=%s", validServer))
 	h.ServeHTTP(w, r)
 
@@ -66,7 +66,7 @@ func TestAuthenticateReturnsClientFailureWhenClientStringIsInvalid(t *testing.T)
 		{"VerComesSecond", b64("cmd=query\nver=1")},
 	}
 
-	h := ssp.Authenticate(anyServer(), NewStore())
+	h := ssp.Authenticate(anyServer(), NewStore(), anyTokenGenerator())
 
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestAuthenticateReturnsClientFailureWhenClientStringIsInvalid(t *testing.T)
 
 func TestAuthenticateReturnsCurrentIDMatchWhenIDIsKnown(t *testing.T) {
 	w, r := setupAuthenticate(validQueryBody)
-	h := ssp.Authenticate(anyServer(), NewStore().ReturnsKnownIdentity())
+	h := ssp.Authenticate(anyServer(), NewStore().ReturnsKnownIdentity(), anyTokenGenerator())
 
 	h.ServeHTTP(w, r)
 
@@ -96,7 +96,7 @@ func TestAuthenticateReturnsCurrentIDMatchWhenIDIsKnown(t *testing.T) {
 
 func TestAuthenticateReturnsNoIDMatchWhenIDIsUnknown(t *testing.T) {
 	w, r := setupAuthenticate(validQueryBody)
-	h := ssp.Authenticate(anyServer(), NewStore().ReturnsUnknownIdentity())
+	h := ssp.Authenticate(anyServer(), NewStore().ReturnsUnknownIdentity(), anyTokenGenerator())
 
 	h.ServeHTTP(w, r)
 
@@ -108,7 +108,7 @@ func TestAuthenticateReturnsNoIDMatchWhenIDIsUnknown(t *testing.T) {
 
 func TestAuthenticateReturnsClientErrorWhenSignatureInvalid(t *testing.T) {
 	w, r := setupAuthenticate(invalidQuerySignature)
-	h := ssp.Authenticate(anyServer(), NewStore())
+	h := ssp.Authenticate(anyServer(), NewStore(), anyTokenGenerator())
 
 	h.ServeHTTP(w, r)
 
@@ -118,14 +118,15 @@ func TestAuthenticateReturnsClientErrorWhenSignatureInvalid(t *testing.T) {
 	}
 }
 
-// TODO: Update to verify that SaveIdentSuccess is called correctly on store
 func TestAuthenticateCallsStoreSaveIdentSuccessWhenIdentSuccessful(t *testing.T) {
 	store := NewStore().ReturnsKnownIdentity()
 	w, r := setupAuthenticate(validIdentBody)
-	h := ssp.Authenticate(anyServer(), store)
+	h := ssp.Authenticate(anyServer(), store, anyTokenGenerator())
 
 	h.ServeHTTP(w, r)
 
+	// TODO: Rather than simply asserting "not empty" we should check the value
+	// of the token - seems to suggest that the TokenGenerator should be an interface
 	assert.NotEmpty(t, store.Func.SaveIdentSuccess.CalledWith.Token)
 }
 

--- a/ssp/authenticate_test.go
+++ b/ssp/authenticate_test.go
@@ -140,7 +140,3 @@ func setupAuthenticate(body string) (*httptest.ResponseRecorder, *http.Request) 
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	return w, r
 }
-
-func anyServer() *sqrl.Server {
-	return sqrl.Configure(make([]byte, 16))
-}

--- a/ssp/example/index.html
+++ b/ssp/example/index.html
@@ -45,7 +45,7 @@
   </table>
   <div class="red_tight_headline" style="font-size:16pt; margin-top:0.5em;">SQRL Service Provider API Test &amp; Demo
   </div>
-  <form method="post" autocomplete="off" style="text-align: center;">
+  <div style="text-align: center;">
     <img id="probe" style="display:none;" src="http://www.rebindtest.com/open.gif">
 
     <div id="mixed"
@@ -69,9 +69,21 @@
       </div>
     </noscript>
 
-    <div style="margin-bottom:1em;"><b style="font-size:12pt;">This web browser is NOT currently logged into this
-        SQRL demonstration.</b></div>
+    <div style="margin-bottom:1em; font-size:12pt;">
+      {{ if .Authenticated}}
+        <b style="color:#080;">SQRL User” is logged in.</b>
+      {{ else }}
+        <b>This web browser is NOT currently logged into this SQRL demonstration.</b>
+      {{ end }}
+    </div>
 
+    {{ if .Authenticated }}
+
+    <form action="/logout" method="get">
+      <input type="submit" value="Sign Out"/>
+    </form>
+
+    {{ else }}
     <table cellspacing="0" cellpadding="0" style='margin: auto;'>
       <tr>
         <td style="text-align:center; font-family:Arial, Helvetica, sans-serif; font-size:9pt; color:#444;">
@@ -140,26 +152,14 @@
     <script>
       SQRL.inject({ api: '/sqrl' })
     </script>
+    {{ end }}
 
     <div style="position:fixed; bottom:0%; width:100%; background:#fff; border-top:#ccc 1px solid; padding-top:3px;">
-
-      <table cellspacing="0" cellpadding="0" class="mono" style="width:100%; font-size:11pt; color:#888">
-        <tr>
-          <td style="width:33%;">Non-SQRL sign In: <span style="color:#000">---</span></td>
-          <td style="width:33%;">SQRL identity recovery: <span style="color:#000">---</span></td>
-        </tr>
-      </table>
-
-      <table cellspacing="0" cellpadding="0" class="mono" style="width:100%; font-size:11pt; color:#888">
-        <tr>
-          <td style="width:33%;">SQRL ID: <span style="color:#000">---</span></td>
-          <td style="width:33%;">Browser Session: <span style="color:#000">{{ .Session }}</span></td>
-          <td style="width:33%;">Account ID: <span style="color:#000">---</span></td>
-        </tr>
-      </table>
-
+      <div style="text-align:center; padding: 1rem;">SQRL ID: <span style="color:#000">
+        {{if .Authenticated }}{{ .UserID }}{{else}}---{{end}}</span>
+      </div>
     </div>
-  </form>
+  </div>
 </body>
 
 </html>

--- a/ssp/example/main.go
+++ b/ssp/example/main.go
@@ -55,6 +55,13 @@ func main() {
 
 func authCallbackHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			log.Printf("Callback called without token")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		if _, err := w.Write([]byte("TODO")); err != nil {
 			log.Printf("Failed to write callback response: %v", err)
 		}

--- a/ssp/example/main.go
+++ b/ssp/example/main.go
@@ -83,10 +83,7 @@ func authCallbackHandler(sspTokenURL string) http.HandlerFunc {
 		}
 
 		// TODO: Set cookie instead of returning user id
-		// TODO: Redirect the client
-		if _, err := w.Write([]byte("Got user with id: " + userId)); err != nil {
-			log.Printf("Failed to write callback response: %+v", err)
-		}
+		http.Redirect(w, r, "/", http.StatusFound)
 	}
 }
 

--- a/ssp/example/main.go
+++ b/ssp/example/main.go
@@ -31,7 +31,7 @@ func main() {
 		// in ssp and configured here. Should we only provide
 		// the /sqrl part here? Or should cli.sqrl be moved out
 		// of ssp.Handler?
-		WithCLientEndpoint("/sqrl/cli.sqrl")
+		WithClientEndpoint("/sqrl/cli.sqrl")
 
 	serverToServerProtection := func(r *http.Request) error {
 		if r.Header.Get("X-Client-Secret") != clientSecret {

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func Handler(s *sqrl.Server) http.Handler {
+func Handler(s *sqrl.Server, authFunc ServerToServerAuthValidationFunc) http.Handler {
 	// TODO: Make this configurable
 	logger := log.New(os.Stdout, "", 0)
 
@@ -25,6 +25,13 @@ func Handler(s *sqrl.Server) http.Handler {
 	r.HandleFunc("/qr.png", qrHandler(s, logger))
 	r.Handle("/cli.sqrl", Authenticate(s, store))
 	r.Handle("/pag.sqrl", PagHandler(s, store))
+
+	userStore := &todoUserStore{}
+	protect := ServerToServerAuthMiddleware(authFunc, logger)
+	r.Handle("/tokens", protect(TokenHandler(s, userStore, logger))).Methods(http.MethodGet)
+	// r.Handle("/users", protect(AddUserHandler(userStore, logger))).Methods(http.MethodPost)
+	// r.Handle("/users", protecte(DeleteUserHandler(userStore, logger))).Methods(http.MethodDelete)
+
 	return r
 }
 

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -28,7 +28,7 @@ func Handler(s *sqrl.Server, authFunc ServerToServerAuthValidationFunc) http.Han
 
 	userStore := &todoUserStore{}
 	protect := ServerToServerAuthMiddleware(authFunc, logger)
-	r.Handle("/tokens", protect(TokenHandler(s, userStore, logger))).Methods(http.MethodGet)
+	r.Handle("/token", protect(TokenHandler(s, userStore, logger))).Methods(http.MethodGet)
 	// r.Handle("/users", protect(AddUserHandler(userStore, logger))).Methods(http.MethodPost)
 	// r.Handle("/users", protecte(DeleteUserHandler(userStore, logger))).Methods(http.MethodDelete)
 

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -107,3 +107,7 @@ func requestDomain(r *http.Request) string {
 	// TODO: Do we need to do anything special here for proxies?
 	return r.Host
 }
+
+func getTokenRedirectURL(server *sqrl.Server, token string) string {
+	return fmt.Sprintf("%s?token=%s", server.RedirectURL(), token)
+}

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -19,16 +19,16 @@ func Handler(s *sqrl.Server, authFunc ServerToServerAuthValidationFunc) http.Han
 	logger := log.New(os.Stdout, "", 0)
 
 	store := NewMemoryStore()
+	tokens := NewTokenGenerator(s.Key())
 
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", nutHandler(s, logger))
 	r.HandleFunc("/qr.png", qrHandler(s, logger))
-	r.Handle("/cli.sqrl", Authenticate(s, store, &todoTokenStore{}, &todoUserStore{}))
+	r.Handle("/cli.sqrl", Authenticate(s, store, tokens, &todoUserStore{}))
 	r.Handle("/pag.sqrl", PagHandler(s, store))
 
-	tokenStore := &todoTokenStore{}
 	protect := ServerToServerAuthMiddleware(authFunc, logger)
-	r.Handle("/token", protect(TokenHandler(s, tokenStore, logger))).Methods(http.MethodGet)
+	r.Handle("/token", protect(TokenHandler(s, tokens, logger))).Methods(http.MethodGet)
 	// r.Handle("/users", protect(AddUserHandler(userStore, logger))).Methods(http.MethodPost)
 	// r.Handle("/users", protecte(DeleteUserHandler(userStore, logger))).Methods(http.MethodDelete)
 

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -23,12 +23,12 @@ func Handler(s *sqrl.Server, authFunc ServerToServerAuthValidationFunc) http.Han
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", nutHandler(s, logger))
 	r.HandleFunc("/qr.png", qrHandler(s, logger))
-	r.Handle("/cli.sqrl", Authenticate(s, store))
+	r.Handle("/cli.sqrl", Authenticate(s, store, &todoTokenStore{}, &todoUserStore{}))
 	r.Handle("/pag.sqrl", PagHandler(s, store))
 
-	userStore := &todoUserStore{}
+	tokenStore := &todoTokenStore{}
 	protect := ServerToServerAuthMiddleware(authFunc, logger)
-	r.Handle("/token", protect(TokenHandler(s, userStore, logger))).Methods(http.MethodGet)
+	r.Handle("/token", protect(TokenHandler(s, tokenStore, logger))).Methods(http.MethodGet)
 	// r.Handle("/users", protect(AddUserHandler(userStore, logger))).Methods(http.MethodPost)
 	// r.Handle("/users", protecte(DeleteUserHandler(userStore, logger))).Methods(http.MethodDelete)
 

--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -24,7 +24,7 @@ func Handler(s *sqrl.Server, authFunc ServerToServerAuthValidationFunc) http.Han
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", nutHandler(s, logger))
 	r.HandleFunc("/qr.png", qrHandler(s, logger))
-	r.Handle("/cli.sqrl", Authenticate(s, store, tokens, &todoUserStore{}))
+	r.Handle("/cli.sqrl", Authenticate(s, store, tokens))
 	r.Handle("/pag.sqrl", PagHandler(s, store))
 
 	protect := ServerToServerAuthMiddleware(authFunc, logger)

--- a/ssp/handler_pag.go
+++ b/ssp/handler_pag.go
@@ -1,7 +1,6 @@
 package ssp
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 
@@ -27,7 +26,7 @@ func PagHandler(server *sqrl.Server, store Store) http.Handler {
 			return
 		}
 
-		url := fmt.Sprintf("%s?%s", server.RedirectURL(), token)
+		url := getTokenRedirectURL(server, token)
 		if _, err := w.Write([]byte(url)); err != nil {
 			log.Printf("Failed to write pag.sqrl response: %v", err)
 		}

--- a/ssp/handler_test.go
+++ b/ssp/handler_test.go
@@ -122,6 +122,10 @@ func anyServer() *sqrl.Server {
 	return sqrl.Configure(make([]byte, 16))
 }
 
+func anyTokenGenerator() *ssp.TokenGenerator {
+	return ssp.NewTokenGenerator(make([]byte, 16))
+}
+
 func noProtection() ssp.ServerToServerAuthValidationFunc {
 	return func(r *http.Request) error {
 		// Allow all server-to-server requests through

--- a/ssp/handler_token.go
+++ b/ssp/handler_token.go
@@ -1,0 +1,67 @@
+package ssp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	sqrl "github.com/RaniSputnik/sqrl-go"
+)
+
+type User struct {
+	Id string
+}
+
+// TODO: Where's the best place to put this? Extend the existing Store interface?
+// Or a new store interface entirely?
+type UserStore interface {
+	GetAuthenticatedUser(ctx context.Context, token string) (*User, error)
+}
+
+type todoUserStore struct{}
+
+func (s *todoUserStore) GetAuthenticatedUser(ctx context.Context, token string) (*User, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TokenHandler is an endpoint repsonsible for validating and exchanging the token
+// issued to the client for user details so that the resource server can associate
+// that SQRL user with their own copy of the user identity.
+func TokenHandler(s *sqrl.Server, store UserStore, logger *log.Logger) http.Handler {
+	type tokenResponse struct {
+		User string `json:"user"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		if err := validateToken(token); err != nil {
+			logger.Printf("Token validation failed: %+v", err)
+			// TODO: Standardise error responses
+			// An invalid token is the same as a token that does not exist
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		user, err := store.GetAuthenticatedUser(r.Context(), token)
+		if err != nil {
+			logger.Printf("Failed to GetAuthenticatedUser: %+v", err)
+			// TODO: Standardise error responses
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		res := tokenResponse{User: user.Id}
+		if err := json.NewEncoder(w).Encode(res); err != nil {
+			logger.Printf("User write unsuccessful: %v", err)
+		}
+	})
+}
+
+func validateToken(token string) error {
+	// TODO: Check token was signed by this server
+	// TODO: Check token has not expired
+
+	return errors.New("not implemented")
+}

--- a/ssp/middleware.go
+++ b/ssp/middleware.go
@@ -1,0 +1,25 @@
+package ssp
+
+import (
+	"log"
+	"net/http"
+)
+
+type ServerToServerAuthValidationFunc func(r *http.Request) error
+
+type middleware func(http.Handler) http.Handler
+
+func ServerToServerAuthMiddleware(validator ServerToServerAuthValidationFunc, logger *log.Logger) middleware {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := validator(r); err != nil {
+				logger.Printf("%s %s Invalid: %+v", r.Method, r.URL, err)
+				// TODO: Standardise error responses
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/ssp/store.go
+++ b/ssp/store.go
@@ -39,26 +39,6 @@ type Transaction struct {
 	// Server string
 }
 
-// TODO: We probably don't need this
-// We should instead store the userId in token itself
-// Along with the token expiry
-type TokenStore interface {
-	// This method is pretty gross - it'd be easy to mix up token and user id
-	// TODO: Stronger type for either token, userId or both
-	SaveToken(ctx context.Context, token string, userId string) error
-	GetUserForToken(ctx context.Context, token string) (userId string, err error)
-}
-
-type todoTokenStore struct{}
-
-func (s *todoTokenStore) SaveToken(ctx context.Context, token string, userId string) error {
-	return errors.New("not implemented")
-}
-
-func (s *todoTokenStore) GetUserForToken(ctx context.Context, token string) (userId string, err error) {
-	return "", errors.New("not implemented")
-}
-
 type UserStore interface {
 	CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error)
 

--- a/ssp/store.go
+++ b/ssp/store.go
@@ -7,7 +7,7 @@ import (
 	sqrl "github.com/RaniSputnik/sqrl-go"
 )
 
-type Store interface {
+type TransactionStore interface {
 	// GetFirstTransaction returns the transaction that started an exchange between
 	// a SQRL client and SSP server. If no error or transaction is returned then
 	// the current transaction is the first transaction in the exchange.
@@ -56,6 +56,11 @@ type User struct {
 	Id  string
 	Idk sqrl.Identity
 	// TODO: Do we need to store previous identity keys?
+}
+
+type Store interface {
+	TransactionStore
+	UserStore
 }
 
 type todoUserStore struct{}

--- a/ssp/store.go
+++ b/ssp/store.go
@@ -2,6 +2,7 @@ package ssp
 
 import (
 	"context"
+	"errors"
 
 	sqrl "github.com/RaniSputnik/sqrl-go"
 )
@@ -23,13 +24,10 @@ type Store interface {
 	// GetIdentSuccess returns a previously saved token for a given transaction nut
 	// if such a token exists. An empty string will be returned if the given nut
 	// has not yet been saved as successful.
-	GetIdentSuccess(ct context.Context, nut sqrl.Nut) (token string, err error)
+	GetIdentSuccess(ctx context.Context, nut sqrl.Nut) (token string, err error)
 
-	// GetIsKnown returns whether the given sqrl identity has been seen in
-	// previous SQRL transactions.
-	// TODO: Clarify exactly when a identity is considered "known"
-	// is it after a successful query? Or after successful ident?
-	GetIsKnown(ctx context.Context, id sqrl.Identity) (bool, error)
+	// Superceeded by UserStore.GetUserForToken
+	// GetIsKnown(ctx context.Context, id sqrl.Identity) (bool, error)
 }
 
 // TODO: Save this to the DB each time a new query is made
@@ -39,4 +37,53 @@ type Transaction struct {
 	Next sqrl.Nut
 	// Client string
 	// Server string
+}
+
+// TODO: We probably don't need this
+// We should instead store the userId in token itself
+// Along with the token expiry
+type TokenStore interface {
+	// This method is pretty gross - it'd be easy to mix up token and user id
+	// TODO: Stronger type for either token, userId or both
+	SaveToken(ctx context.Context, token string, userId string) error
+	GetUserForToken(ctx context.Context, token string) (userId string, err error)
+}
+
+type todoTokenStore struct{}
+
+func (s *todoTokenStore) SaveToken(ctx context.Context, token string, userId string) error {
+	return errors.New("not implemented")
+}
+
+func (s *todoTokenStore) GetUserForToken(ctx context.Context, token string) (userId string, err error) {
+	return "", errors.New("not implemented")
+}
+
+type UserStore interface {
+	CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error)
+
+	// GetByIdentity returns a user from the given identity key.
+	// If no user is found, a nil user will be returned with no error.
+	// TODO: Clarify exactly when a user should be saved
+	// is it after a successful query? Or after successful ident?
+	// see: https://github.com/RaniSputnik/sqrl-go/issues/25
+	GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*User, error)
+
+	// TODO: Get by previous identities
+}
+
+type User struct {
+	Id  string
+	Idk sqrl.Identity
+	// TODO: Do we need to store previous identity keys?
+}
+
+type todoUserStore struct{}
+
+func (s *todoUserStore) CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *todoUserStore) GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*User, error) {
+	return nil, errors.New("not implemented")
 }

--- a/ssp/store.go
+++ b/ssp/store.go
@@ -2,7 +2,6 @@ package ssp
 
 import (
 	"context"
-	"errors"
 
 	sqrl "github.com/RaniSputnik/sqrl-go"
 )
@@ -61,14 +60,4 @@ type User struct {
 type Store interface {
 	TransactionStore
 	UserStore
-}
-
-type todoUserStore struct{}
-
-func (s *todoUserStore) CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (s *todoUserStore) GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*User, error) {
-	return nil, errors.New("not implemented")
 }

--- a/ssp/store_inmemory.go
+++ b/ssp/store_inmemory.go
@@ -2,7 +2,8 @@ package ssp
 
 import (
 	"context"
-	"errors"
+	"crypto/rand"
+	"fmt"
 	"sync"
 
 	sqrl "github.com/RaniSputnik/sqrl-go"
@@ -67,9 +68,35 @@ func (s *inmemoryStore) GetIdentSuccess(ctx context.Context, nut sqrl.Nut) (toke
 }
 
 func (s *inmemoryStore) CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error) {
-	return nil, errors.New("not implemented")
+	s.Lock()
+	defer s.Unlock()
+	newUser := &User{
+		Id:  uuid(),
+		Idk: idk,
+	}
+	s.users = append(s.users, newUser)
+	return newUser, nil
 }
 
 func (s *inmemoryStore) GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*User, error) {
-	return nil, errors.New("not implemented")
+	s.Lock()
+	defer s.Unlock()
+
+	for _, user := range s.users {
+		if user.Idk == idk {
+			return user, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func uuid() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }

--- a/ssp/store_inmemory.go
+++ b/ssp/store_inmemory.go
@@ -2,6 +2,7 @@ package ssp
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	sqrl "github.com/RaniSputnik/sqrl-go"
@@ -11,6 +12,7 @@ type inmemoryStore struct {
 	transactions      map[sqrl.Nut]*Transaction
 	firstTransactions map[sqrl.Nut]sqrl.Nut
 	tokens            map[sqrl.Nut]string
+	users             []*User
 
 	sync.Mutex
 }
@@ -64,9 +66,10 @@ func (s *inmemoryStore) GetIdentSuccess(ctx context.Context, nut sqrl.Nut) (toke
 	return s.tokens[nut], nil
 }
 
-func (s *inmemoryStore) GetIsKnown(ctx context.Context, id sqrl.Identity) (bool, error) {
-	// TODO: what point is an identity is considered "known"
-	// eg. is it after a successful query? Or is "known" only
-	// saved after a successful ident?
-	return false, nil
+func (s *inmemoryStore) CreateUser(ctx context.Context, idk sqrl.Identity) (*User, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *inmemoryStore) GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*User, error) {
+	return nil, errors.New("not implemented")
 }

--- a/ssp/store_inmemory_test.go
+++ b/ssp/store_inmemory_test.go
@@ -91,5 +91,53 @@ func TestMemoryStoreIdent(t *testing.T) {
 }
 
 func TestMemoryStoreUsers(t *testing.T) {
-	// TODO: Add tests for user functions
+	ctx := context.TODO()
+
+	t.Run("CreatesUserReturnsAUser", func(t *testing.T) {
+		s := ssp.NewMemoryStore()
+		user, err := s.CreateUser(ctx, "someidk")
+		assert.Nil(t, err)
+		assert.NotNil(t, user)
+	})
+
+	// TODO: What to do if we attempt to create a user with the same IDK?
+
+	t.Run("CreateUserUsesAUniqueIDForTheUser", func(t *testing.T) {
+		s := ssp.NewMemoryStore()
+		user1, _ := s.CreateUser(ctx, "idk1")
+		user2, _ := s.CreateUser(ctx, "idk2")
+		if assert.NotNil(t, user1) && assert.NotNil(t, user2) {
+			assert.NotEmpty(t, user1.Id)
+			assert.NotEmpty(t, user2.Id)
+			assert.NotEqual(t, user1.Id, user2.Id)
+		}
+	})
+
+	t.Run("CreateUserSetsTheNewUsersIDKCorrectly", func(t *testing.T) {
+		s := ssp.NewMemoryStore()
+		idk := sqrl.Identity("someidk")
+		user, _ := s.CreateUser(ctx, idk)
+		if assert.NotNil(t, user) {
+			assert.Equal(t, idk, user.Idk)
+		}
+	})
+
+	t.Run("GetUserByIdentityReturnsKnownUser", func(t *testing.T) {
+		s := ssp.NewMemoryStore()
+		idk := sqrl.Identity("someidk")
+		user, _ := s.CreateUser(ctx, idk)
+
+		fetchedUser, err := s.GetUserByIdentity(ctx, idk)
+		assert.Nil(t, err)
+		if assert.NotNil(t, fetchedUser) {
+			assert.Equal(t, user.Id, fetchedUser.Id)
+		}
+	})
+
+	t.Run("GetUserByIdentityReturnsNilIfUserNotFound", func(t *testing.T) {
+		s := ssp.NewMemoryStore()
+		fetchedUser, err := s.GetUserByIdentity(ctx, "someidk")
+		assert.Nil(t, err)
+		assert.Nil(t, fetchedUser)
+	})
 }

--- a/ssp/store_inmemory_test.go
+++ b/ssp/store_inmemory_test.go
@@ -89,3 +89,7 @@ func TestMemoryStoreIdent(t *testing.T) {
 		assert.Equal(t, givenToken, gotToken)
 	})
 }
+
+func TestMemoryStoreUsers(t *testing.T) {
+	// TODO: Add tests for user functions
+}

--- a/ssp/store_mock_test.go
+++ b/ssp/store_mock_test.go
@@ -48,15 +48,24 @@ type mockStore struct {
 				Err   error
 			}
 		}
-		// TODO: Remove me
-		GetIsKnown struct {
+		CreateUser struct {
 			CalledWith struct {
 				Ctx context.Context
-				Id  sqrl.Identity
+				Idk sqrl.Identity
 			}
 			Returns struct {
-				IsKnown bool
-				Err     error
+				User *ssp.User
+				Err  error
+			}
+		}
+		GetUserByIdentity struct {
+			CalledWith struct {
+				Ctx context.Context
+				Idk sqrl.Identity
+			}
+			Returns struct {
+				User *ssp.User
+				Err  error
 			}
 		}
 	}
@@ -87,10 +96,16 @@ func (m *mockStore) GetIdentSuccess(ctx context.Context, nut sqrl.Nut) (token st
 	return m.Func.GetIdentSuccess.Returns.Token, m.Func.GetIdentSuccess.Returns.Err
 }
 
-func (m *mockStore) GetIsKnown(ctx context.Context, id sqrl.Identity) (bool, error) {
-	m.Func.GetIsKnown.CalledWith.Ctx = ctx
-	m.Func.GetIsKnown.CalledWith.Id = id
-	return m.Func.GetIsKnown.Returns.IsKnown, m.Func.GetIsKnown.Returns.Err
+func (m *mockStore) CreateUser(ctx context.Context, idk sqrl.Identity) (*ssp.User, error) {
+	m.Func.CreateUser.CalledWith.Ctx = ctx
+	m.Func.CreateUser.CalledWith.Idk = idk
+	return m.Func.CreateUser.Returns.User, m.Func.CreateUser.Returns.Err
+}
+
+func (m *mockStore) GetUserByIdentity(ctx context.Context, idk sqrl.Identity) (*ssp.User, error) {
+	m.Func.GetUserByIdentity.CalledWith.Ctx = ctx
+	m.Func.GetUserByIdentity.CalledWith.Idk = idk
+	return m.Func.GetUserByIdentity.Returns.User, m.Func.GetUserByIdentity.Returns.Err
 }
 
 // Language helpers
@@ -100,13 +115,16 @@ func NewStore() *mockStore {
 }
 
 func (m *mockStore) ReturnsUnknownIdentity() *mockStore {
-	m.Func.GetIsKnown.Returns.IsKnown = false
-	m.Func.GetIsKnown.Returns.Err = nil
+	m.Func.GetUserByIdentity.Returns.User = nil
+	m.Func.GetUserByIdentity.Returns.Err = nil
 	return m
 }
 
 func (m *mockStore) ReturnsKnownIdentity() *mockStore {
-	m.Func.GetIsKnown.Returns.IsKnown = true
-	m.Func.GetIsKnown.Returns.Err = nil
+	m.Func.GetUserByIdentity.Returns.User = &ssp.User{
+		Id:  "someuser",
+		Idk: "abc123",
+	}
+	m.Func.GetUserByIdentity.Returns.Err = nil
 	return m
 }

--- a/ssp/store_mock_test.go
+++ b/ssp/store_mock_test.go
@@ -48,6 +48,7 @@ type mockStore struct {
 				Err   error
 			}
 		}
+		// TODO: Remove me
 		GetIsKnown struct {
 			CalledWith struct {
 				Ctx context.Context

--- a/ssp/token.go
+++ b/ssp/token.go
@@ -1,0 +1,148 @@
+package ssp
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type token struct {
+	UserId    string
+	CreatedAt int64
+}
+
+func defaultNowFunc() time.Time {
+	return time.Now()
+}
+
+// TODO: There is a lot of similarities here between sqrl.Server
+// and the token generator - how could we share more of the logic
+// between the two? Maybe managed aes is not required?
+func NewTokenGenerator(key []byte) *TokenGenerator {
+	aesgcm := genAesgcm(key)
+	return &TokenGenerator{
+		aesgcm:      aesgcm,
+		tokenExpiry: time.Minute,
+		NowFunc:     defaultNowFunc,
+	}
+}
+
+type TokenGenerator struct {
+	aesgcm      cipher.AEAD
+	tokenExpiry time.Duration
+
+	NowFunc func() time.Time
+}
+
+func (g *TokenGenerator) Token(userId string) string {
+	if strings.Contains(userId, ",") {
+		// Defensive against sneaky (and probably malicious) userIds
+		panic("userId must not contain commas (,)")
+	}
+	t := g.encryptToken(token{
+		UserId:    userId,
+		CreatedAt: g.NowFunc().Unix(),
+	})
+	return string(t)
+}
+
+var (
+	ErrTokenExpired       = errors.New("token expired")
+	ErrTokenFormatInvalid = errors.New("token format invalid")
+)
+
+func (g *TokenGenerator) ValidateToken(token string) error {
+	t, err := g.decryptToken(token)
+	if err != nil {
+		return ErrTokenFormatInvalid
+	}
+	issuedAt := time.Unix(t.CreatedAt, 0)
+	if g.NowFunc().Sub(issuedAt) > g.tokenExpiry {
+		return ErrTokenExpired
+	}
+	// TODO: Any kind of validation needed of user id?
+	return nil
+}
+
+var b64 = base64.URLEncoding.WithPadding(base64.NoPadding)
+
+func (g *TokenGenerator) encryptToken(t token) string {
+	payload := fmt.Sprintf("%s,%d", t.UserId, t.CreatedAt)
+	nonce := randBytes(g.aesgcm.NonceSize())
+	// TODO: Ensure payload is of suitable length
+	encryptedToken := g.aesgcm.Seal(nil, nonce, []byte(payload), nil)
+	encryptedTokenAndNonce := append(nonce, encryptedToken...)
+	return b64.EncodeToString(encryptedTokenAndNonce)
+}
+
+func (g *TokenGenerator) decryptToken(t string) (token, error) {
+	invalidToken := token{}
+	encryptedTokenAndNonce, err := b64.DecodeString(t)
+	if err != nil {
+		return invalidToken, err
+	}
+	nonceSize := g.aesgcm.NonceSize()
+	if len(encryptedTokenAndNonce) <= nonceSize {
+		return invalidToken, errors.New("token length less than nonce size")
+	}
+	nonce := encryptedTokenAndNonce[:nonceSize]
+	encryptedToken := encryptedTokenAndNonce[nonceSize:]
+
+	decryptedToken, err := g.aesgcm.Open(nil, nonce, encryptedToken, nil)
+	if err != nil {
+		return invalidToken, err
+	}
+
+	tokenParts := strings.Split(string(decryptedToken), ",")
+	if len(tokenParts) != 2 {
+		return invalidToken, errors.New("token should have exactly one comma")
+	}
+	userId := tokenParts[0]
+	createdAt, err := strconv.ParseInt(tokenParts[1], 10, 64)
+	if err != nil {
+		return invalidToken, err
+	}
+
+	return token{
+		UserId:    userId,
+		CreatedAt: createdAt,
+	}, nil
+}
+
+func randBytes(length int) []byte {
+	noise := make([]byte, length)
+	if _, err := io.ReadFull(rand.Reader, noise); err != nil {
+		// Token generation does not currently return
+		// an error as there is little recourse available
+		// to a consumer.
+		// It is probably safe to assume that a failure
+		// to read random noise is a non-recoverable error.
+		// This is an assumption that should be tested.
+		panic(err.Error())
+	}
+	return noise
+}
+
+func genAesgcm(key []byte) cipher.AEAD {
+	padKeyIfRequired(key)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err.Error())
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		panic(err.Error())
+	}
+	return aesgcm
+}
+
+func padKeyIfRequired(key []byte) {
+	// TODO: Ensure key is either 16, 24 or 32 bits
+}

--- a/ssp/token.go
+++ b/ssp/token.go
@@ -59,14 +59,13 @@ var (
 )
 
 func (g *TokenGenerator) ValidateToken(token string) (userId string, err error) {
-	emptyUserId := ""
 	t, err := g.decryptToken(token)
 	if err != nil {
-		return emptyUserId, ErrTokenFormatInvalid
+		return "", ErrTokenFormatInvalid
 	}
 	issuedAt := time.Unix(t.CreatedAt, 0)
 	if g.NowFunc().Sub(issuedAt) > g.tokenExpiry {
-		return emptyUserId, ErrTokenExpired
+		return "", ErrTokenExpired
 	}
 	// TODO: Any kind of validation needed of user id?
 	return t.UserId, nil

--- a/ssp/token.go
+++ b/ssp/token.go
@@ -58,17 +58,18 @@ var (
 	ErrTokenFormatInvalid = errors.New("token format invalid")
 )
 
-func (g *TokenGenerator) ValidateToken(token string) error {
+func (g *TokenGenerator) ValidateToken(token string) (userId string, err error) {
+	emptyUserId := ""
 	t, err := g.decryptToken(token)
 	if err != nil {
-		return ErrTokenFormatInvalid
+		return emptyUserId, ErrTokenFormatInvalid
 	}
 	issuedAt := time.Unix(t.CreatedAt, 0)
 	if g.NowFunc().Sub(issuedAt) > g.tokenExpiry {
-		return ErrTokenExpired
+		return emptyUserId, ErrTokenExpired
 	}
 	// TODO: Any kind of validation needed of user id?
-	return nil
+	return t.UserId, nil
 }
 
 var b64 = base64.URLEncoding.WithPadding(base64.NoPadding)

--- a/ssp/token_test.go
+++ b/ssp/token_test.go
@@ -42,23 +42,32 @@ func TestTokenValidation(t *testing.T) {
 
 	t.Run("ReturnsNoErrorForValidToken", func(t *testing.T) {
 		validToken := "hq84C7vMmeYtNPo5oEdsSDI2rCjpWAvs-U04DvVuQ79uVVBvHq--MwabFJVfbbI"
-		err := generator.ValidateToken(validToken)
+		_, err := generator.ValidateToken(validToken)
 		assert.Nil(t, err)
 	})
 
+	t.Run("ReturnsUserIDForValidToken", func(t *testing.T) {
+		validToken := "hq84C7vMmeYtNPo5oEdsSDI2rCjpWAvs-U04DvVuQ79uVVBvHq--MwabFJVfbbI"
+		expectedUserID := "someUser"
+		uid, _ := generator.ValidateToken(validToken)
+		assert.Equal(t, expectedUserID, uid)
+	})
+
 	t.Run("ReturnsTokenExpiredForOldToken", func(t *testing.T) {
+		// Token generated at 2019-06-22 15:32:00 +0100 BST
+		// Expiry set to 1 minute by default
 		expiredToken := "Mq1C2bWBM7-gld_1bj_h7yZiL0OLggOxkuq6KXD7JTcuuykuZ0DljmpzTKpZBv8"
-		err := generator.ValidateToken(expiredToken)
+		_, err := generator.ValidateToken(expiredToken)
 		assert.Equal(t, ssp.ErrTokenExpired, err)
 	})
 
 	t.Run("ReturnsTokenFormatInvalidForEmptyToken", func(t *testing.T) {
-		err := generator.ValidateToken("")
+		_, err := generator.ValidateToken("")
 		assert.Equal(t, ssp.ErrTokenFormatInvalid, err)
 	})
 
 	t.Run("ReturnsTokenFormatInvalidForRandomString", func(t *testing.T) {
-		err := generator.ValidateToken("someinvalidtoken")
+		_, err := generator.ValidateToken("someinvalidtoken")
 		assert.Equal(t, ssp.ErrTokenFormatInvalid, err)
 	})
 }

--- a/ssp/token_test.go
+++ b/ssp/token_test.go
@@ -1,0 +1,64 @@
+package ssp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RaniSputnik/sqrl-go/ssp"
+	"github.com/stretchr/testify/assert"
+
+	"encoding/base64"
+)
+
+var anyKey = make([]byte, 16)
+
+func TestTokenGeneration(t *testing.T) {
+	generator := ssp.NewTokenGenerator(anyKey)
+
+	t.Run("ReturnsAToken", func(t *testing.T) {
+		got := generator.Token("someUser")
+		t.Logf("Generated token: %s", got)
+		assert.NotEmpty(t, got)
+	})
+
+	t.Run("Base64EncodesTheToken", func(t *testing.T) {
+		got := generator.Token("someUser")
+		_, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(got)
+		t.Logf("Generated token: %s", got)
+		assert.Nil(t, err)
+	})
+
+	t.Run("EncodesAReallyLongUserId", func(t *testing.T) {
+		got := generator.Token("areallylonguseridthatiscompletelyunreasonable")
+		t.Logf("Generated token: %s", got)
+		assert.NotEmpty(t, got)
+	})
+}
+
+func TestTokenValidation(t *testing.T) {
+	generator := ssp.NewTokenGenerator(anyKey)
+	currentTime, _ := time.Parse("2006-01-02 15:04:05 -0700 MST", "2019-06-22 15:35:06 +0100 BST")
+	generator.NowFunc = func() time.Time { return currentTime }
+
+	t.Run("ReturnsNoErrorForValidToken", func(t *testing.T) {
+		validToken := "hq84C7vMmeYtNPo5oEdsSDI2rCjpWAvs-U04DvVuQ79uVVBvHq--MwabFJVfbbI"
+		err := generator.ValidateToken(validToken)
+		assert.Nil(t, err)
+	})
+
+	t.Run("ReturnsTokenExpiredForOldToken", func(t *testing.T) {
+		expiredToken := "Mq1C2bWBM7-gld_1bj_h7yZiL0OLggOxkuq6KXD7JTcuuykuZ0DljmpzTKpZBv8"
+		err := generator.ValidateToken(expiredToken)
+		assert.Equal(t, ssp.ErrTokenExpired, err)
+	})
+
+	t.Run("ReturnsTokenFormatInvalidForEmptyToken", func(t *testing.T) {
+		err := generator.ValidateToken("")
+		assert.Equal(t, ssp.ErrTokenFormatInvalid, err)
+	})
+
+	t.Run("ReturnsTokenFormatInvalidForRandomString", func(t *testing.T) {
+		err := generator.ValidateToken("someinvalidtoken")
+		assert.Equal(t, ssp.ErrTokenFormatInvalid, err)
+	})
+}


### PR DESCRIPTION
This PR adds an endpoint for a resource server to exchange a token issued by the SSP server for a user id. This user id can then be associated with the resource servers understanding of the user to help link their SQRL identity and user profile together.

- [x] Add server-to-server authentication configuration option
- [x] Add server-to-server auth middleware
- [x] Add token endpoint
- [x] Token validation
- [x] Save user when authentication completed
- [x] Retrieve user by token
- [x] Redirect to homepage from auth callback
- [x] Save login state in cookie
- [x] Show a different page when logged in