### PR TITLE
Add store and token exchange config options

### DIFF
--- a/ssp/handler.go
+++ b/ssp/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	qrcode "github.com/skip2/go-qrcode"
 
@@ -13,16 +12,13 @@ import (
 )
 
 func (s *Server) Handler() http.Handler {
-	store := NewMemoryStore()
-	tokens := DefaultExchange(s.key, time.Minute)
-
 	r := mux.NewRouter().StrictSlash(false)
 	r.HandleFunc("/nut.json", s.NutHandler())
 	r.HandleFunc("/qr.png", s.QRCodeHandler())
-	r.Handle("/cli.sqrl", s.ClientHandler(store, tokens))
-	r.Handle("/pag.sqrl", s.PagHandler(store))
+	r.Handle("/cli.sqrl", s.ClientHandler(s.store, s.exchange))
+	r.Handle("/pag.sqrl", s.PagHandler(s.store))
 
-	r.Handle("/token", s.TokenHandler(tokens)).Methods(http.MethodGet)
+	r.Handle("/token", s.TokenHandler(s.exchange)).Methods(http.MethodGet)
 	// r.Handle("/users", protect(AddUserHandler(userStore, logger))).Methods(http.MethodPost)
 	// r.Handle("/users", protecte(DeleteUserHandler(userStore, logger))).Methods(http.MethodDelete)
 

--- a/ssp/ssp.go
+++ b/ssp/ssp.go
@@ -17,6 +17,8 @@ func (_ donothingLogger) Printf(format string, v ...interface{}) {}
 type Server struct {
 	key []byte
 
+	store          Store
+	exchange       TokenExchange
 	logger         Logger
 	validator      ServerToServerAuthValidationFunc
 	redirectURL    string
@@ -26,12 +28,16 @@ type Server struct {
 }
 
 func Configure(key []byte, redirectURL string) *Server {
+	store := NewMemoryStore()
+	exchange := DefaultExchange(key, time.Minute)
 	nutter := sqrl.NewNutter(key)
 
 	return &Server{
 		key: key,
 
-		logger: donothingLogger{},
+		store:    store,
+		exchange: exchange,
+		logger:   donothingLogger{},
 		// TODO: Is there a more sensible default we could use here?
 		validator:      noProtection,
 		redirectURL:    redirectURL,
@@ -39,6 +45,16 @@ func Configure(key []byte, redirectURL string) *Server {
 
 		nutter: nutter,
 	}
+}
+
+func (s *Server) WithStore(store Store) *Server {
+	s.store = store
+	return s
+}
+
+func (s *Server) WithTokenExchange(exchange TokenExchange) *Server {
+	s.exchange = exchange
+	return s
 }
 
 func (s *Server) WithLogger(l Logger) *Server {


### PR DESCRIPTION
Not really sure of the correct interface for these config options. It's a bit odd that in the `Handler` method, you're given no opportunity to configure `Store` or `TokenExchange` but in the individual handlers you are.

A summary of my thinking:
* It's nice (especially for testing) that you can see the dependencies required for each individual handler.
* I think it's more intuitive that these things are configured on `ssp.Server` rather than when we create the handler.
* `Handler` isn't really doing much anymore... maybe it should be removed?
* `Logger` is configured on `ssp.Server` and is not passed explicitly to individual handler methods, shouldn't it be treated the same as other dependencies?